### PR TITLE
fix: don't setup log if not using the CLI

### DIFF
--- a/src/rtfparse/__init__.py
+++ b/src/rtfparse/__init__.py
@@ -3,7 +3,7 @@
 
 # Towncrier needs version
 from rtfparse.__about__ import __version__
-from rtfparse.cli import main
 
 if __name__ == "__main__":
+    from rtfparse.cli import main
     main()


### PR DESCRIPTION
Hi, we have an issue where we are using the RTF parser as a library, and the code in the CLI is being run, specifically the logging setup, without need.