### PR TITLE
remove `removesuffix` to support python 3.8

### DIFF
--- a/src/rtfparse/entities.py
+++ b/src/rtfparse/entities.py
@@ -81,7 +81,8 @@ class Control_Word(Entity):
             if parameter is not None:
                 self.parameter = int(parameter.decode(self.encoding))
                 logger.debug(f"{self.parameter = }")
-                self.control_name = self.control_name.removesuffix(str(self.parameter))
+                if self.control_name.endswith(str(self.parameter)):
+                    self.control_name = self.control_name[: -len(str(self.parameter))]
                 logger.debug(f"Final {self.control_name = }")
             target_position = self.start_position + match.span()[1]
             if match.group("other"):


### PR DESCRIPTION
I needed a rtf parser for python 3.8 and this was the closest library I could find that met my purposes. Python 3.8 is the last supported python version on windows 7 which unfortunately I need to target.

This library contained a single incompatibility: `removesuffix`. Like most of 3.9's changes, it can easily be rewritten to support 3.8's functionality.

I have been using this library for over an hour and have not found any other incompatibilities with python 3.8.

if there are any other code segments this PR can backport please let me know.