### PR TITLE
38 - Issue with ordered and unordered lists

### DIFF
--- a/src/rtfparse/renderers/html_decapsulator.py
+++ b/src/rtfparse/renderers/html_decapsulator.py
@@ -33,6 +33,9 @@ class HTML_Decapsulator(Renderer):
             "colortbl",
             "generator",
             "formatConverter",
+            "pntext",
+            "pntxta",
+            "pntxtb",
         )
 
     def ignore_rtf_toggle(self, cw: entities.Control_Word) -> str:


### PR DESCRIPTION
- Added `pntext`, `pntxta` and `pntxtb` groups to the `ignore_groups` prop to fix issue with invalid enriching of the decapsulated HTML

Closes #38